### PR TITLE
Replace County Codes with Unique 3 Letters Codes

### DIFF
--- a/bika/accel/adapters/idgenerator.py
+++ b/bika/accel/adapters/idgenerator.py
@@ -1,6 +1,7 @@
 from bika.lims.interfaces import IIdServer
 from zope.interface import implements
 from bika.lims.locales import COUNTRIES, STATES
+from bika.accel.config import COUNTY_CODES
 from Products.CMFCore.utils import getToolByName
 import re
 
@@ -77,8 +78,15 @@ class IDGenerator(object):
             if country['Country'] == self.context.getCountry():
                 country = country['ISO']
                 break
-        for state in STATES:
-            if state[0] == country and state[2] == self.context.getProvince():
-                province = state[1]
+
+        # First we will check if the county has 3 letter abbreviation, if not then return just number
+        for c in COUNTY_CODES:
+            if self.context.getProvince() == c.get('title'):
+                province = c.get("tla")
                 break
+        else:
+            for state in STATES:
+                if state[0] == country and state[2] == self.context.getProvince():
+                    province = state[1]
+                    break
         return country, province

--- a/bika/accel/config.py
+++ b/bika/accel/config.py
@@ -5,3 +5,22 @@ from bika.accel import bikaMessageFactory as _
 from bika.accel.permissions import *
 
 PROJECTNAME = "bika.accel"
+
+# County THREE LETTER ACRONYMS (TLA), in order to generate IDs
+COUNTY_CODES = [
+    {"title": "Bomi", "tla": "BOM", "bika_code": "15"},
+    {"title": "Bong", "tla": "BON", "bika_code": "01"},
+    {"title": "Gbarpolu", "tla": "GBR", "bika_code": "21"},
+    {"title": "Grand Bassa", "tla": "GRB", "bika_code": "11"},
+    {"title": "Grand Cape Mount", "tla": "GRC", "bika_code": "12"},
+    {"title": "Grand Gedeh", "tla": "GRG", "bika_code": "19"},
+    {"title": "Grand Kru", "tla": "GRK", "bika_code": "16"},
+    {"title": "Lofa", "tla": "LOF", "bika_code": "20"},
+    {"title": "Margibi", "tla": "MAR", "bika_code": "17"},
+    {"title": "Maryland", "tla": "MAL", "bika_code": "13"},
+    {"title": "Montserrado", "tla": "MON", "bika_code": "14"},
+    {"title": "Nimba", "tla": "NIM", "bika_code": "09"},
+    {"title": "River Gee", "tla": "RGE", "bika_code": "22"},
+    {"title": "River Cess", "tla": "RIV", "bika_code": "18"},
+    {"title": "Sinoe", "tla": "SIN", "bika_code": "10"},
+]


### PR DESCRIPTION
In order to have identical Client (Facility) IDs with ACCEL IDSR, 3 Letters County Codes were added and used in ID generation for Clients.